### PR TITLE
fix: conventional-commits: handle dependabot hyphen

### DIFF
--- a/.github/actions/conventional-commits/action.yml
+++ b/.github/actions/conventional-commits/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: actions/github-script@v5
       with:
         script: |
-          const validator = /^(chore|feat|fix|revert|docs|style)(\((((CCIE|CDI|PRODSEC|SECENG|ONCALL)-[0-9]+)|([a-z]+))\))?(!)?: (.)+$/
+          const validator = /^(chore|feat|fix|revert|docs|style)(\((((CCIE|CDI|PRODSEC|SECENG|ONCALL)-[0-9]+)|([a-z-]+))\))?(!)?: (.)+$/
           const title = context.payload.pull_request.title
           const is_valid = validator.test(title)
 


### PR DESCRIPTION
- changing regex from [a-z] to [a-z-]
- resolves https://github.com/chanzuckerberg/github-actions/issues/234